### PR TITLE
fix: invalid proof verification

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "tapestry",
       "dependencies": {
-        "@coral-xyz/anchor": "^0.31.0",
+        "@coral-xyz/anchor": "^0.29.0",
         "@lightprotocol/stateless.js": "^0.20.9",
         "drizzle-kit": "^0.26.2",
         "drizzle-orm": "^0.35.1",
@@ -19,11 +19,9 @@
   "packages": {
     "@babel/runtime": ["@babel/runtime@7.26.10", "", { "dependencies": { "regenerator-runtime": "^0.14.0" } }, "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw=="],
 
-    "@coral-xyz/anchor": ["@coral-xyz/anchor@0.31.0", "", { "dependencies": { "@coral-xyz/anchor-errors": "^0.31.0", "@coral-xyz/borsh": "^0.31.0", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.69.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-Yb1NwP1s4cWhAw7wL7vOLHSWWw3cD5D9pRCVSeJpdqPaI+w7sfRLScnVJL6ViYMZynB7nAG/5HcUPKUnY0L9rw=="],
+    "@coral-xyz/anchor": ["@coral-xyz/anchor@0.29.0", "", { "dependencies": { "@coral-xyz/borsh": "^0.29.0", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.68.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "crypto-hash": "^1.3.0", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "snake-case": "^3.0.4", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA=="],
 
-    "@coral-xyz/anchor-errors": ["@coral-xyz/anchor-errors@0.31.0", "", {}, "sha512-SUERksFSQ+4F11hkROIwHq4mcoSMXJxwVWLoklefi4dU679zVWFVcTq6O7otvjY8wlUaRXeE+iYcQWZTw2ll6w=="],
-
-    "@coral-xyz/borsh": ["@coral-xyz/borsh@0.31.0", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.69.0" } }, "sha512-DwdQ5fuj+rGQCTKRnxnW1W2lvcpBaFc9m9M1TcGGlm+bwCcggmDgbLKLgF+LjIrKnc7Nd+bCACx5RA9YTK2I4Q=="],
+    "@coral-xyz/borsh": ["@coral-xyz/borsh@0.29.0", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.68.0" } }, "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
@@ -135,9 +133,13 @@
 
     "cross-fetch": ["cross-fetch@3.2.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q=="],
 
+    "crypto-hash": ["crypto-hash@1.3.0", "", {}, "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg=="],
+
     "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
     "delay": ["delay@5.0.0", "", {}, "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw=="],
+
+    "dot-case": ["dot-case@3.0.4", "", { "dependencies": { "no-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w=="],
 
     "drizzle-kit": ["drizzle-kit@0.26.2", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.1", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.19.7", "esbuild-register": "^3.5.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-cMq8omEKywjIy5KcqUo6LvEFxkl8/zYHsgYjFVXjmPWWtuW4blcz+YW9+oIhoaALgs2ebRjzXwsJgN9i6P49Dw=="],
 
@@ -175,9 +177,13 @@
 
     "jsonparse": ["jsonparse@1.3.1", "", {}, "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="],
 
+    "lower-case": ["lower-case@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg=="],
+
     "map-obj": ["map-obj@5.0.0", "", {}, "sha512-2L3MIgJynYrZ3TYMriLDLWocz15okFakV6J12HXvMXDHui2x/zgChzg1u9mFFGbbGWE+GsLpQByt4POb9Or+uA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "no-case": ["no-case@3.0.4", "", { "dependencies": { "lower-case": "^2.0.2", "tslib": "^2.0.3" } }, "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
@@ -196,6 +202,8 @@
     "rpc-websockets": ["rpc-websockets@9.1.1", "", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/uuid": "^8.3.4", "@types/ws": "^8.2.2", "buffer": "^6.0.3", "eventemitter3": "^5.0.1", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-1IXGM/TfPT6nfYMIXkJdzn+L4JEsmb0FL1O2OBjaH03V3yuUDdKFulGLMFG6ErV+8pZ5HVC0limve01RyO+saA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "snake-case": ["snake-case@3.0.4", "", { "dependencies": { "dot-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -244,8 +252,6 @@
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@libsql/client-wasm/@libsql/libsql-wasm-experimental": ["@libsql/libsql-wasm-experimental@0.0.2", "", { "bundled": true, "bin": { "sqlite-wasm": "bin/index.js" } }, "sha512-xkiu88QwozGr3KEt9h0zeHLYUIWkeDchXmuOUW4/Wh/mRZkDlNtIIePAR0FiLl1j0o4OyTEOtPnvmaXQ5MNTKQ=="],
-
-    "@lightprotocol/stateless.js/@coral-xyz/borsh": ["@coral-xyz/borsh@0.29.0", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.68.0" } }, "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ=="],
 
     "@lightprotocol/stateless.js/@noble/hashes": ["@noble/hashes@1.5.0", "", {}, "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": "20.18.0"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "^0.31.0",
+    "@coral-xyz/anchor": "^0.29.0",
     "@lightprotocol/stateless.js": "^0.20.9",
     "drizzle-kit": "^0.26.2",
     "drizzle-orm": "^0.35.1"

--- a/packages/tapestry/package.json
+++ b/packages/tapestry/package.json
@@ -10,18 +10,18 @@
     "build:rust": "cargo build --release",
     "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
     "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check",
-    "start:local": "rm -rf test-ledger && light test-validator ",
-    "airdrop:local": "solana airdrop 1000 37TCH5eyngJKEQ3CbPZYCGqjSCdMH4wUTAuHSspxA2nJ -u http://localhost:8899",
-    "deploy:local": "anchor deploy --program-name tapestry --provider.cluster http://localhost:8899  --program-keypair ../../keys/GraphU.json  --provider.wallet ../../keys/provider-wallet.json",
+    "start:local": "rm -rf test-ledger && light test-validator",
+    "airdrop:local": "solana airdrop 1000 --keypair ../../keys/provider-wallet.json -u http://localhost:8899",
+    "deploy:local": "anchor deploy --program-name tapestry --provider.cluster http://localhost:8899  --program-keypair ../../keys/GraphU.json  --provider.wallet ../../keys/provider-wallet.json ",
     "extend": "solana program extend GraphUyqhPmEAckWzi7zAvbvUTXf8kqX7JtuvdGYRDRh 19000 -u $MAINNET_RPC -k ../../keys/authority-keypair.json",
     "extend:local": "solana program extend GraphUyqhPmEAckWzi7zAvbvUTXf8kqX7JtuvdGYRDRh 30000 -u http://localhost:8899 -k ../../keys/authority-keypair.json",
     "write-buffer": "solana program write-buffer --with-compute-unit-price 1000 target/deploy/tapestry.so -u $MAINNET_RPC -k ../../keys/authority-keypair.json --buffer buffer.json --max-sign-attempts 1000 --use-rpc",
     "deploy": "solana program deploy --with-compute-unit-price 1000 -u $MAINNET_RPC -k ../../keys/authority-keypair.json --buffer buffer.json --program-id ../../keys/program-keypair.json",
-    "test": "anchor test --skip-deploy --skip-local-validator --skip-build --provider.wallet ../../keys/authority-keypair.json -- --timeout 30000",
+    "test": "anchor test --skip-deploy --skip-local-validator --skip-build --provider.wallet ../../keys/authority-keypair.json --log -- --timeout 30000",
     "close-buffers": "solana program close --buffers -u $MAINNET_RPC -k ../../keys/authority-keypair.json",
     "idl:init": "anchor idl init -f target/idl/tapestry.json GraphUyqhPmEAckWzi7zAvbvUTXf8kqX7JtuvdGYRDRh --provider.wallet ../../keys/provider-wallet.json --provider.cluster https://devnet.helius-rpc.com/?api-key=f30d6a96-5fa2-4318-b2da-0f6d1deb5c83",
     "idl": "anchor idl upgrade -f target/idl/tapestry.json GraphUyqhPmEAckWzi7zAvbvUTXf8kqX7JtuvdGYRDRh --provider.wallet ../../keys/provider-wallet.json --provider.cluster https://devnet.helius-rpc.com/?api-key=f30d6a96-5fa2-4318-b2da-0f6d1deb5c83",
-    "test:local": "bun run generate-wallets && bun start:local && bun run airdrops.ts && bun build:program && bun deploy:local && bun test"
+    "test:local": "bun run generate-wallets && bun start:local && bun run airdrop:local && bun build:program && bun deploy:local && bun test"
   },
   "dependencies": {
     "@coral-xyz/anchor": "0.29.0",

--- a/packages/tapestry/programs/tapestry/src/utils/get_account_seed.rs
+++ b/packages/tapestry/programs/tapestry/src/utils/get_account_seed.rs
@@ -1,11 +1,11 @@
 use anchor_lang::prelude::*;
-use light_utils::hash_to_bn254_field_size_be;
+use light_utils::hashv_to_bn254_field_size_be;
 
 use crate::AccountKey;
 
-pub fn get_account_seed<'info>(account_key: AccountKey, asset_id: &[u8; 32]) -> [u8; 32] {
+pub fn get_account_seed(account_key: AccountKey, asset_id: &[u8; 32]) -> [u8; 32] {
     let account_key_bytes = account_key.try_to_vec().unwrap();
     let account_type_bytes: &[u8] = &[account_key_bytes[0]];
-    let input = [account_type_bytes, &crate::ID.to_bytes(), asset_id].concat();
-    hash_to_bn254_field_size_be(input.as_slice()).unwrap().0
+    let input = [&crate::ID.to_bytes(), account_type_bytes, asset_id].concat();
+    hashv_to_bn254_field_size_be(&[&input])
 }

--- a/packages/tapestry/tests/common.ts
+++ b/packages/tapestry/tests/common.ts
@@ -17,9 +17,9 @@ export const NAME_KEYPAIR = anchor.web3.Keypair.fromSecretKey(
 );
 
 // Define RPC endpoint
-export const RPC_ENDPOINT = "http://localhost:8899";
-export const COMPRESS_RPC_ENDPOINT = "http://localhost:8784";
-export const PROVER_ENDPOINT = "http://localhost:3001";
+export const RPC_ENDPOINT = "http://127.0.0.1:8899";
+export const COMPRESS_RPC_ENDPOINT = "http://127.0.0.1:8784";
+export const PROVER_ENDPOINT = "http://127.0.0.1:3001";
 // Create connection
 export const connection = createRpc(
   RPC_ENDPOINT,

--- a/packages/tapestry/tests/tapestry.test.ts
+++ b/packages/tapestry/tests/tapestry.test.ts
@@ -17,7 +17,7 @@ import {
 } from "@lightprotocol/stateless.js";
 //@ts-expect-error
 import { describe, it } from "bun:test";
-import { Keypair } from "@solana/web3.js";
+import { Keypair, SendTransactionError } from "@solana/web3.js";
 import idl from "../target/idl/tapestry.json";
 import * as borsh from "borsh";
 
@@ -208,11 +208,15 @@ describe("tapestry", () => {
       });
       console.log("Transaction signature:", signature);
     } catch (error) {
+      if (error instanceof SendTransactionError) {
+        const logs = await error.getLogs(rpc);
+        console.error("Transaction failed with logs:", logs);
+      }
       throw Error(error);
     }
   });
 
-  it.skip("can fetch nodes by owner", async () => {
+  it("can fetch nodes by owner", async () => {
     // Add a delay to allow the transaction to be processed
     const nodes = await rpc.getCompressedAccountsByOwner(program.programId, {
       filters: [


### PR DESCRIPTION
### Problem

client and program derive `address_seed` differently, resulting in proofs for the wrong PDA.

### Fix

• reorders seeds: `account_type_bytes, crate::ID, asset_id` to `crate::ID, account_type_bytes, asset_id`

• uses `hashv_to_bn254_field_size_be` instead of `hash_to_bn254_field_size_be` for consistency with client.
